### PR TITLE
Edited driver to support BayerGB to RGB conversion

### DIFF
--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -19,8 +19,8 @@
 # Don't set your version to anything such as "test" that
 # could match a directory name.
 # ==========================================================
-ADCORE_MODULE_VERSION   = R3.10-1.1.1
-ASYN_MODULE_VERSION     = R4.39-1.0.2
+ADCORE_MODULE_VERSION   = R3.10-1.1.0
+ASYN_MODULE_VERSION     = R4.39-1.0.1
 
 # ==========================================================
 # Define module paths using pattern

--- a/prosilicaApp/src/prosilica.cpp
+++ b/prosilicaApp/src/prosilica.cpp
@@ -592,10 +592,11 @@ void prosilica::frameCallback(tPvFrame *pFrame)
                                 driverName, functionName, bayerConvert );
                             break;
                         case PSBayerConvertRGB1: {
-                            PvUtilityColorInterpolate(pFrame, pData, pData+1, pData+2, 2, 0);
+                            int rowSize = pFrame->Width;
+                            PvUtilityColorInterpolate(pFrame, pData+rowSize, pData, pData+1, 2, 0);
                             colorMode = NDColorModeRGB1;
                             pImage->ndims = 3;
-                            bitsPerPixel    = 24;
+                            bitsPerPixel    = pFrame->BitDepth;;
                             pImage->dims[0].size    = 3;
                             pImage->dims[0].offset  = 0;
                             pImage->dims[0].binning = 1;
@@ -679,10 +680,11 @@ void prosilica::frameCallback(tPvFrame *pFrame)
                                 driverName, functionName, bayerConvert );
                             break;
                         case PSBayerConvertRGB1: {
-                            PvUtilityColorInterpolate(pFrame, pData, pData+1, pData+2, 2, 0);
+                            int rowSize = pFrame->Width;
+                            PvUtilityColorInterpolate(pFrame, pData+rowSize, pData, pData+1, 2, 0);
                             colorMode = NDColorModeRGB1;
                             pImage->ndims = 3;
-                            bitsPerPixel  = 24;
+                            bitsPerPixel  = pFrame->BitDepth;
                             pImage->dims[0].size    = 3;
                             pImage->dims[0].offset  = 0;
                             pImage->dims[0].binning = 1;


### PR DESCRIPTION
Edited src to force bayerConvert type RGB1 to accept BayerGB pixel format. Reverted RELEASE.local to build off older module versions in order to match the RELEASE of the parent IOC in pcdshub/ioc-common-gigecam. 

This adds color support for cameras with BayerGB8 and BayerBG12 pixel formats.